### PR TITLE
Fix problems with keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
 uUart	KEYWORD1
 receive		KEYWORD2
-send	KEYWORD3
-print	KEYWORD4
-init	KEYWORD5
+send	KEYWORD2
+print	KEYWORD2
+init	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,5 +1,5 @@
-uUart       KEYWORD1
-receive	    KEYWORD2
-send        KEYWORD3
-print       KEYWORD4
-init        KEYWORD5
+uUart	KEYWORD1
+receive		KEYWORD2
+send	KEYWORD3
+print	KEYWORD4
+init	KEYWORD5


### PR DESCRIPTION
- Use correct field separator.
- Use correct and valid KEYWORD_TOKENTYPEs.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords